### PR TITLE
fix floating point error in activation when T<-50C

### DIFF
--- a/src/chemistry/oslo_aero/NdParam.f
+++ b/src/chemistry/oslo_aero/NdParam.f
@@ -235,6 +235,15 @@
       DOUBLE PRECISION NACTI, DENOM
       REAL             PDF
 
+      !C Check if temperature is below -50C
+      IF (TPARC.LT.223.0) THEN
+            SMAX  = 0d0
+            NACT  = 0d0
+            ACF = 0d0
+            MACF = 0d0
+            RETURN
+      ENDIF
+
 !C
 !C *** Single updraft case
 !C


### PR DESCRIPTION
When running with debug = True the original code produces a floating point error due to attempt to take the sqrt of a negative number in NdParam.f on line 353 `CF1  = 0.5*(((1/BET2)/(ALFA*WPARC))**0.5)`.  This happens because the function calculating the vapor pressure is not defined for T < -50, thus it gives a negative Saturation vapor pressure. The fix ensure that no aerosols are activated for T < -50 there shouldn't either be any liquid available for activation either at this temperature. 